### PR TITLE
FEAT - Rename keys in players reducer/store to be more semantic

### DIFF
--- a/app/README.md
+++ b/app/README.md
@@ -15,8 +15,8 @@ let sampleState = {
    * - players: This is an array of ids of all the users in the game.
    */
   players: {
-    playersById: { 1: userObj, 2: userObj, 3: userObj },
-    players: ['1', '2', '3'],
+    all: { 1: userObj, 2: userObj, 3: userObj },
+    byId: ['1', '2', '3'],
   },
 
   /* This is an object which represents attributes of the

--- a/app/reducers/__tests__/players.js
+++ b/app/reducers/__tests__/players.js
@@ -4,8 +4,8 @@ import { SOCKET_PLAYER_JOIN_GAME, SOCKET_PLAYER_LEAVE_GAME } from '../../action_
 
 const myInitialState = {
   someOtherKey: true,
-  players: [1],
-  playersById: { 1: {
+  byId: [1],
+  all: { 1: {
     id: 1,
     username: 'bob',
   } },
@@ -31,7 +31,7 @@ describe('Players Reducer', () => {
   it('should add the player to the state if given a "SOCKET_PLAYER_JOIN_GAME" action', () => {
     const myAction = { type: SOCKET_PLAYER_JOIN_GAME, player: { id: 2, username: 'joan' } };
     const myNewState = playerReducer(myInitialState, myAction);
-    expect(myNewState.playersById[2].username).toEqual('joan');
+    expect(myNewState.all[2].username).toEqual('joan');
   });
   it('should keep existing keys when given an action', () => {
     const myAction = { type: SOCKET_PLAYER_JOIN_GAME, player: { id: 2, username: 'joan' } };
@@ -43,7 +43,7 @@ describe('Players Reducer', () => {
     const myState = playerReducer(myInitialState, myAction);
     const myNewAction = { type: SOCKET_PLAYER_LEAVE_GAME, userid: 2 };
     const myNewState = playerReducer(myState, myNewAction);
-    expect(myNewState.playersById[2]).toBe(undefined);
+    expect(myNewState.all[2]).toBe(undefined);
   });
 });
 

--- a/app/reducers/players.js
+++ b/app/reducers/players.js
@@ -1,22 +1,22 @@
 import { SOCKET_PLAYER_JOIN_GAME, SOCKET_PLAYER_LEAVE_GAME } from '../action_types/actionTypes.js';
 
 const mergeNewPlayer = (state, player) => {
-  const playersById = Object.assign({}, state.playersById);
-  playersById[player.id] = player;
+  const all = Object.assign({}, state.all);
+  all[player.id] = player;
   return {
     ...state,
-    players: Object.keys(playersById),
-    playersById,
+    byId: Object.keys(all),
+    all,
   };
 };
 
 const removePlayer = (state, userid) => {
-  const playersById = Object.assign({}, state.playersById);
-  delete playersById[userid];
+  const all = Object.assign({}, state.all);
+  delete all[userid];
   return {
     ...state,
-    players: Object.keys(playersById),
-    playersById,
+    byId: Object.keys(all),
+    all,
   };
 };
 


### PR DESCRIPTION
<!--- Keep this line &  above for command line hub users -->
## Description

<!--- Describe your changes in detail -->

This changes the keys from:
1.  `state.players.playerById -> state.players.all`
2.  `state.players.players -> state.players.byId`

This makes it so that the reducing/mapping of these will be more semantic:

``` javascript
// Returns all players with a username under 5 characters
state.players.byId.filter((id) => {
  return state.players.all[id].username.length < 5;
});
```
## Related Issue(s)

<!--- Please link to the issue here using 'closing' or 'connected': -->

Closes #82
## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes and any tests you've written. -->

Jest
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Major refactor (fix or feature that would cause existing functionality to change)
- [x] Documentation change (Check this if you changed any documentation at all)
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] My code follows the code style of this project.
- [x] I have rebased and squashed my commits.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My change requires a change to the documentation.
