### PR TITLE
Feat/server driven notifications

### DIFF
--- a/app/App.js
+++ b/app/App.js
@@ -1,6 +1,6 @@
 /* Import Dependencies */
 import React, { Dimensions } from 'react-native';
-import { Actions, Scene, Modal, Router, NavBar } from 'react-native-router-flux';
+import { Actions, Scene, Modal, Router } from 'react-native-router-flux';
 import { connect, Provider } from 'react-redux';
 import DeviceInfo from 'react-native-device-info';
 
@@ -9,7 +9,6 @@ import HomeScreen from './screens/HomeScreen.js';
 import GameScreen from './screens/GameScreen.js';
 import StatsScreen from './screens/StatsScreen.js';
 import DealerChangeScreen from './screens/DealerChangeScreen';
-import Toast from './components/Toast.js';
 import CustomNav from './components/CustomNav.js';
 
 
@@ -62,8 +61,13 @@ const scenes = Actions.create(
     <Scene key="root">
       <Scene hideNavBar type="replace" key="showHomeScreen" initial component={HomeScreen} />
       <Scene
-        type="push" key="showGameScreen" component={GameScreen} title="Your game!"
-        onRight={() => Actions.showStatsScreen()} rightTitle="Stats"
+        type="push"
+        key="showGameScreen"
+        component={GameScreen}
+        navBar={CustomNav}
+        title="Your game!"
+        onRight={() => Actions.showStatsScreen()}
+        rightTitle="Stats"
       >
         <Scene
           key="showGameScreen_default"

--- a/app/action_types/actionTypes.js
+++ b/app/action_types/actionTypes.js
@@ -26,7 +26,6 @@ export const SEND_GUESS_MESSAGE = 'server/sendGuessMessage';
 export const SEND_CLUE_MESSAGE = 'server/sendClueMessage';
 
 /**
- * Client->Client: sent from the view to update parts of the ui state being tracked in
- * the store.
+ * Client->Client: Indicates that the user has read the most recent notificaiton.
  */
-export const UPDATE_UI_STATE = 'UPDATE_UI_STATE';
+export const DEQUEUE_GAME_MEMO = 'DEQUEUE_GAME_MEMO';

--- a/app/actions/user.js
+++ b/app/actions/user.js
@@ -1,4 +1,8 @@
-import { SEND_CLUE_MESSAGE, SEND_GUESS_MESSAGE } from '../action_types/actionTypes.js';
+import {
+  SEND_CLUE_MESSAGE,
+  SEND_GUESS_MESSAGE,
+  DEQUEUE_GAME_MEMO,
+} from '../action_types/actionTypes.js';
 
 /**
  * Creates an action for submitting a guess to the server
@@ -20,3 +24,10 @@ export const submitClue = (userid, message) => ({
   message,
 });
 
+/**
+ * This creates an action which removes a memo from the notifications
+ * queue once it has been dismissed by the user.
+ */
+export const dequeueMemo = () => ({
+  type: DEQUEUE_GAME_MEMO,
+});

--- a/app/components/CustomNav.js
+++ b/app/components/CustomNav.js
@@ -1,8 +1,15 @@
+/* Import React/ Redux dependencies */
 import React, {
   PropTypes,
 } from 'react-native';
+import { connect } from 'react-redux';
+
+/* Import Nav Sub Compoents */
 import { NavBar } from 'react-native-router-flux';
 import Toast from './Toast.js';
+
+/* Import Provider */
+import { mapCustomNav } from '../providers/providers.js';
 
 /**
  * CustomNav is a React class component which renders different Headers
@@ -10,13 +17,18 @@ import Toast from './Toast.js';
  * @param {Object} props - props for the component which are pased through to
  * child components wholesale.
  */
-export default class CustomNav extends React.Component {
+export class CustomNav extends React.Component {
   constructor(props) {
     super(props);
-    this.state = { navType: this.props.navType || 'nav' };
+    this.state = { navType: 'nav' };
   }
   componentWillReceiveProps(nextProps) {
-    this.setState({ navType: nextProps.navType });
+    if (nextProps.notifications.length > 0) {
+      this.setState({ navType: 'toast' });
+      this.headerProps = { toastMessage: nextProps.notifications[0].body };
+      return;
+    }
+    this.setState({ navType: 'nav' });
   }
   renderNavigationBar() {
     switch (this.state.navType) {
@@ -31,12 +43,18 @@ export default class CustomNav extends React.Component {
   render() {
     const Header = this.renderNavigationBar();
     return (
-      <Header {...this.props} />
+      <Header {...this.props} {...this.headerProps} />
     );
   }
 }
 
 CustomNav.propTypes = {
-  screenSize: PropTypes.object,
-  navType: PropTypes.string,
+  screenSize: PropTypes.object.isRequired,
 };
+
+const CustomNavContainer = connect(
+  mapCustomNav.mapStateToProps,
+  mapCustomNav.mapDispatchToProps
+)(CustomNav);
+
+export default CustomNavContainer;

--- a/app/components/Toast.js
+++ b/app/components/Toast.js
@@ -55,7 +55,7 @@ const styles = StyleSheet.create({
  */
 class Toast extends React.Component {
   render() {
-    const { toastMessage, screenSize } = this.props;
+    const { toastMessage, screenSize, dequeueMemo } = this.props;
     return (
       <Image
         style={[
@@ -77,9 +77,7 @@ class Toast extends React.Component {
           <View style={styles.row1}>
             <TouchableOpacity
               style={styles.buttonBG}
-              onPress={() => Actions.showGameScreen_default({
-                navType: 'nav',
-              })}
+              onPress={dequeueMemo}
             >
               <Text style={styles.font}> X </Text>
             </TouchableOpacity>
@@ -94,7 +92,8 @@ class Toast extends React.Component {
 }
 Toast.propTypes = {
   toastMessage: PropTypes.string.isRequired,
-  screenSize: PropTypes.object,
+  screenSize: PropTypes.object.isRequired,
+  dequeueMemo: PropTypes.func.isRequred,
 };
 
 export default Toast;

--- a/app/providers/providers.js
+++ b/app/providers/providers.js
@@ -1,5 +1,5 @@
 /* Import Actions */
-import { submitGuess } from '../actions/user.js';
+import { submitGuess, dequeueMemo } from '../actions/user.js';
 import { Actions } from 'react-native-router-flux';
 
 
@@ -38,6 +38,22 @@ export const mapGameScreen = {
          * TODO: remove hardcoded userid
          */
         dispatch(submitGuess(6, message));
+      },
+    };
+  },
+};
+
+/* CustomNav Providers */
+export const mapCustomNav = {
+  mapStateToProps(state) {
+    return {
+      notifications: state.routes.scene.notifications,
+    };
+  },
+  mapDispatchToProps(dispatch) {
+    return {
+      dequeueMemo: () => {
+        dispatch(dequeueMemo());
       },
     };
   },

--- a/app/reducers/routes.js
+++ b/app/reducers/routes.js
@@ -13,7 +13,7 @@ export default function reducer(state = { scene: { notifications: [] } }, action
         scene: newScene,
       };
     case GAME_MEMO:
-      const newNotificaitons = state.scene.notifications.concat([action.payload]);
+      const newNotifications = state.scene.notifications.concat([action.payload]);
       newScene = Object.assign({}, state.scene, {
         notifications: newNotifications
       });

--- a/app/reducers/routes.js
+++ b/app/reducers/routes.js
@@ -1,7 +1,7 @@
-import { GAME_MEMO } from '../action_types/actionTypes.js';
+import { GAME_MEMO, DEQUEUE_GAME_MEMO } from '../action_types/actionTypes.js';
 
 export default function reducer(state = { scene: { notifications: [] } }, action = {}) {
-  let newScene;
+  let newScene, newNotifications;
 
   switch (action.type) {
     case 'focus':
@@ -13,7 +13,17 @@ export default function reducer(state = { scene: { notifications: [] } }, action
         scene: newScene,
       };
     case GAME_MEMO:
-      const newNotifications = state.scene.notifications.concat([action.payload]);
+      newNotifications = state.scene.notifications.concat([action.payload]);
+      newScene = Object.assign({}, state.scene, {
+        notifications: newNotifications
+      });
+      return {
+        ...state,
+        scene: newScene,
+      };
+    case DEQUEUE_GAME_MEMO:
+      newNotifications = state.scene.notifications.slice();
+      newNotifications.pop();
       newScene = Object.assign({}, state.scene, {
         notifications: newNotifications
       });


### PR DESCRIPTION
<!--- Keep this line &  above for command line hub users -->
## Description

<!--- Describe your changes in detail -->

Notifications are now driven completely form store, and dismissing a notification will remove it from the queue in the store. Reducers are set up to receive GAME_MEMOs and add them to the correct part of the store.
## Related Issue(s)

<!--- Please link to the issue here using 'closing' or 'connected': -->

Resolves #107 
## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes and any tests you've written. -->

Tested manually and existing functionality verified with npm test.

TO TEST MANUALLY: Paste the following Action into your dispatcher in the Redux Dev Tools.
{
  type: "GAME_MEMO",
  payload: {
    body: "Brandon won the game!"
  }
}
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Major refactor (fix or feature that would cause existing functionality to change)
- [] Documentation change (Check this if you changed any documentation at all)
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] My code follows the code style of this project.
- [X] I have rebased and squashed my commits.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
- [ ] My change requires a change to the documentation.
