### PR TITLE
FEAT - Implement logic to render keyboard dynamically in GameScreen b…

### DIFF
--- a/app/App.js
+++ b/app/App.js
@@ -8,7 +8,6 @@ import DeviceInfo from 'react-native-device-info';
 import HomeScreen from './screens/HomeScreen.js';
 import GameScreen from './screens/GameScreen.js';
 import StatsScreen from './screens/StatsScreen.js';
-import DealerChangeScreen from './screens/DealerChangeScreen';
 import CustomNav from './components/CustomNav.js';
 
 
@@ -20,9 +19,9 @@ const store = configureStore({});
 import { fakeGameCreator } from './testdata/dummyData.js';
 store.dispatch(fakeGameCreator());
 
-/* Fetch user information */
+/* Fetch user information (REMOVE 'then' block for production)*/
 fetch(`http://localhost:1234/api/user/${DeviceInfo.getUniqueID()}`)
-  .then((res) => { // This `then` block should be removed when the server syncs up with ui development
+  .then((res) => {
     if (!res.ok) {
       return {
         id: 0,

--- a/app/actions/__tests__/user.js
+++ b/app/actions/__tests__/user.js
@@ -1,5 +1,5 @@
 jest.unmock('../user.js');
-import { submitGuess, submitClue } from '../user.js';
+import { sendGuess, sendClue } from '../user.js';
 import { SEND_GUESS_MESSAGE, SEND_CLUE_MESSAGE } from '../../action_types/actionTypes.js';
 
 describe('User Action Types', () => {
@@ -13,33 +13,32 @@ describe('User Action Types', () => {
   });
 });
 
-describe('submitGuess Action Creator', () => {
+describe('sendGuess Action Creator', () => {
   it('should be a function', () => {
-    expect(typeof submitGuess).toEqual('function');
+    expect(typeof sendGuess).toEqual('function');
   });
   it('should return an object', () => {
-    expect(typeof submitGuess(6, 'tree')).toEqual('object');
+    expect(typeof sendGuess(6, 'tree')).toEqual('object');
   });
   it('should have a type property of SUBMIT_GUESS', () => {
-    expect(submitGuess(6, 'tree').type).toEqual(SEND_GUESS_MESSAGE);
+    expect(sendGuess(6, 'tree').type).toEqual(SEND_GUESS_MESSAGE);
   });
   it('should have a guess property of passed in guess', () => {
-    expect(submitGuess(6, 'tree').message).toEqual('tree');
+    expect(sendGuess(6, 'tree').message).toEqual('tree');
   });
 });
 
-describe('submitClue Action Creator', () => {
+describe('sendClue Action Creator', () => {
   it('should be a function', () => {
-    expect(typeof submitClue).toEqual('function');
+    expect(typeof sendClue).toEqual('function');
   });
   it('should return an object', () => {
-    expect(typeof submitClue(6, 'leaf')).toEqual('object');
+    expect(typeof sendClue(6, 'leaf')).toEqual('object');
   });
   it('should have a type property of SEND_CLUE_MESSAGE', () => {
-    expect(submitClue(6, 'leaf').type).toEqual(SEND_CLUE_MESSAGE);
+    expect(sendClue(6, 'leaf').type).toEqual(SEND_CLUE_MESSAGE);
   });
   it('should have a hint property of passed in hint', () => {
-    expect(submitClue(6, 'leaf').message).toEqual('leaf');
+    expect(sendClue(6, 'leaf').message).toEqual('leaf');
   });
 });
-

--- a/app/actions/user.js
+++ b/app/actions/user.js
@@ -8,7 +8,7 @@ import {
  * Creates an action for submitting a guess to the server
  * This action is handled by the server
  */
-export const submitGuess = (userid, message) => ({
+export const sendGuess = (userid, message) => ({
   type: SEND_GUESS_MESSAGE,
   userid,
   message,
@@ -18,7 +18,7 @@ export const submitGuess = (userid, message) => ({
  * This creates an action for the dealer to submit a clue
  * This action is handeled by the server
  */
-export const submitClue = (userid, message) => ({
+export const sendClue = (userid, message) => ({
   type: SEND_CLUE_MESSAGE,
   userid,
   message,

--- a/app/components/PlayerInput.js
+++ b/app/components/PlayerInput.js
@@ -43,7 +43,16 @@ const styles = StyleSheet.create({
   },
 });
 
-const PlayerInput = ({ onSubmitEditing, screenSize }) => (
+
+/**
+ * PlayerInput is a funcitonal react component which renders a styled text
+ * input which triggers the native keyboard when in focus.
+ * @param {Object} props - props for GameScreen component.
+ * @param {Object} props.screenSize - dimensions of the device screen.
+ * @param {function()} props.onSend - handler to be called to when user
+ * enters input and hits send.
+ */
+const PlayerInput = ({ onSend, screenSize }) => (
   <View
     style={[
       styles.container,
@@ -58,7 +67,7 @@ const PlayerInput = ({ onSubmitEditing, screenSize }) => (
         style={styles.inputField}
         placeholder="Input your guess"
         returnKeyType="send"
-        onSubmitEditing={(event) => (onSubmitEditing(event.nativeEvent.text))}
+        onSubmitEditing={(event) => (onSend(event.nativeEvent.text))}
       />
       <Button
         style={styles.send}
@@ -72,7 +81,8 @@ const PlayerInput = ({ onSubmitEditing, screenSize }) => (
 );
 
 PlayerInput.propTypes = {
-  onSubmitEditing: PropTypes.func.isRequired,
+  onSend: PropTypes.func.isRequired,
+  screenSize: PropTypes.object.isRequired,
 };
 
 export default PlayerInput;

--- a/app/components/__tests__/PlayerInputTest.js
+++ b/app/components/__tests__/PlayerInputTest.js
@@ -28,7 +28,7 @@ describe('PlayerInput', () => {
   beforeEach(() => {
     const renderer = TestUtils.createRenderer();
     renderer.render(<PlayerInput
-      onSubmitEditing={submitGuess}
+      onSend={submitGuess}
       onFocus={onFocus}
       screenSize={screenSize}
     />);

--- a/app/providers/providers.js
+++ b/app/providers/providers.js
@@ -1,5 +1,5 @@
 /* Import Actions */
-import { submitGuess, dequeueMemo } from '../actions/user.js';
+import { sendGuess, sendClue, dequeueMemo } from '../actions/user.js';
 import { Actions } from 'react-native-router-flux';
 
 
@@ -27,17 +27,25 @@ export const mapHomeScreen = {
 /* Game Screen Providers*/
 export const mapGameScreen = {
   mapStateToProps(state) {
+    const isDealer = state.game.dealerId === state.user.id;
     return {
       messages: state.messages,
+      isDealer,
     };
   },
   mapDispatchToProps(dispatch) {
     return {
-      onSubmitGuess: (message) => {
+      onSendGuess: (message) => {
         /**
          * TODO: remove hardcoded userid
          */
-        dispatch(submitGuess(6, message));
+        dispatch(sendGuess(6, message));
+      },
+      onSendClue: (message) => {
+        /**
+         * TODO: remove hardcoded userid
+         */
+        dispatch(sendClue(6, message));
       },
     };
   },

--- a/app/screens/GameScreen.js
+++ b/app/screens/GameScreen.js
@@ -16,6 +16,7 @@ import React, {
 } from 'react-native';
 import PlayerInput from '../components/PlayerInput.js';
 import ChatsList from '../components/ChatsList.js';
+import EmojiKeyboard from '../components/EmojiKeyboard';
 
 const { height: screenHeight, width: screenWidth } = Dimensions.get('window');
 
@@ -30,17 +31,20 @@ const styles = StyleSheet.create({
   },
 });
 
-/* eslint-disable react/prefer-stateless-function */
 /**
  * GameScreen is a React class component.
  * It defines the game room players will see while playing the game.
  * It displays messages as well as allows for user input form either the dealer
  * or the players who are guessing.
  * @param {Object} props - props for GameScreen component.
- * @param {function()} props.onSubmitGuess - handler for receiving user input
+ * @param {function()} props.onSendGuess - handler for receiving players input
  * in the PlayerInput component.
  * @param {Array<Object>} props.messages - an array of message objects to be
  * rendered by the ChatsList component.
+ * @param {function()} props.onSendClue - handler for receiving dealer input.
+ * @param {bool} props.isDealer - indicates whether game screen should render
+ * in player or dealer mode.
+ *
  */
 export class GameScreen extends React.Component {
   constructor(props) {
@@ -83,31 +87,39 @@ export class GameScreen extends React.Component {
     DeviceEventEmitter.removeAllListeners('keyboardWillShow');
   }
 
+  renderKeyboardInput() {
+    return this.props.isDealer ? EmojiKeyboard : PlayerInput;
+  }
+
   /* We must calculate styles on each render in order to animate height
    * based on state changes
    */
   render() {
-    const { messages, onSubmitGuess, showToast, toastMessage, screenSize } = this.props;
+    const { messages, onSendGuess, onSendClue, screenSize } = this.props;
     const localStyles = StyleSheet.create({
       container: {
         height: this.state.visibleHeight,
       },
     });
+    const KeyboardInput = this.renderKeyboardInput();
     return (
       <View style={[styles.container, localStyles.container]} >
         <ChatsList style={styles.chatContainer} messages={messages} />
-        <PlayerInput onSubmitEditing={onSubmitGuess} screenSize={screenSize} />
+        <KeyboardInput
+          onSend={this.props.isDealer ? onSendClue : onSendGuess}
+          screenSize={screenSize}
+        />
       </View>
     );
   }
 }
-/* eslint-enable react/prefer-stateless-function */
 
 GameScreen.propTypes = {
-  onSubmitGuess: PropTypes.func.isRequired,
+  onSendGuess: PropTypes.func.isRequired,
+  onSendClue: PropTypes.func.isRequired,
   messages: PropTypes.array.isRequired,
-  showToast: PropTypes.bool,
-  toastMessage: PropTypes.string,
+  isDealer: PropTypes.bool,
+  screenSize: PropTypes.object.isRequired,
 };
 
 /**


### PR DESCRIPTION
<!--- Keep this line &  above for command line hub users -->
## Description

<!--- Describe your changes in detail -->

Integrated GameScreen with user and game domains of the store. Integrated emoji keyboard with GameScreen and it now renders when the user is the current dealer.
## Related Issue(s)

<!--- Please link to the issue here using 'closing' or 'connected': -->

Resolves #136
Resolves #137
## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes and any tests you've written. -->

Tested manually and with jest. 

To test manually, must manually configure store to have user id be the same as current dealer (by setting it in the initial state on the reducer or via some other means).
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [X] Major refactor (fix or feature that would cause existing functionality to change)
- [X] Documentation change (Check this if you changed any documentation at all)
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] My code follows the code style of this project.
- [X] I have rebased and squashed my commits.
- [] I have added tests to cover my changes.
- [X] All new and existing tests passed.
- [ ] My change requires a change to the documentation.

…ased on whether user is player or dealer.
