### PR TITLE
FEAT - Refactor notificaitons queeue (now memos) into its own reducer…

### DIFF
--- a/app/components/CustomNav.js
+++ b/app/components/CustomNav.js
@@ -25,7 +25,7 @@ export class CustomNav extends React.Component {
   componentWillReceiveProps(nextProps) {
     if (nextProps.notifications.length > 0) {
       this.setState({ navType: 'toast' });
-      this.headerProps = { toastMessage: nextProps.notifications[0].body };
+      this.setState({ headerProps: { toastMessage: nextProps.notifications[0].body } });
       return;
     }
     this.setState({ navType: 'nav' });
@@ -43,7 +43,7 @@ export class CustomNav extends React.Component {
   render() {
     const Header = this.renderNavigationBar();
     return (
-      <Header {...this.props} {...this.headerProps} />
+      <Header {...this.props} {...this.state.headerProps} />
     );
   }
 }

--- a/app/providers/providers.js
+++ b/app/providers/providers.js
@@ -56,7 +56,7 @@ export const mapGameScreen = {
 export const mapCustomNav = {
   mapStateToProps(state) {
     return {
-      notifications: state.routes.scene.notifications,
+      notifications: state.memos,
     };
   },
   mapDispatchToProps(dispatch) {

--- a/app/reducers/index.js
+++ b/app/reducers/index.js
@@ -3,12 +3,14 @@ import messages from './messages.js';
 import game from './game.js';
 import routes from './routes.js';
 import user from './user.js';
+import memos from './memos.js';
 
 const rootReducer = combineReducers({
   messages,
   game,
   routes,
   user,
+  memos,
 });
 
 export default rootReducer;

--- a/app/reducers/memos.js
+++ b/app/reducers/memos.js
@@ -1,0 +1,12 @@
+import { GAME_MEMO, DEQUEUE_GAME_MEMO } from '../action_types/actionTypes.js';
+
+export default function reducer(state = [], action = {}) {
+  switch (action.type) {
+    case GAME_MEMO:
+      return state.concat([action.payload]);
+    case DEQUEUE_GAME_MEMO:
+      return state.slice(1);
+    default:
+      return state;
+  }
+}

--- a/app/reducers/routes.js
+++ b/app/reducers/routes.js
@@ -1,35 +1,10 @@
-import { GAME_MEMO, DEQUEUE_GAME_MEMO } from '../action_types/actionTypes.js';
-
-export default function reducer(state = { scene: { notifications: [] } }, action = {}) {
-  let newScene, newNotifications;
+export default function reducer(state = { scene: {} }, action = {}) {
 
   switch (action.type) {
     case 'focus':
-    const notifications = Array.prototype.slice.apply(state.scene.notifications);
-    newScene = action.scene;
-    newScene.notifications = notifications;
       return {
         ...state,
-        scene: newScene,
-      };
-    case GAME_MEMO:
-      newNotifications = state.scene.notifications.concat([action.payload]);
-      newScene = Object.assign({}, state.scene, {
-        notifications: newNotifications
-      });
-      return {
-        ...state,
-        scene: newScene,
-      };
-    case DEQUEUE_GAME_MEMO:
-      newNotifications = state.scene.notifications.slice();
-      newNotifications.pop();
-      newScene = Object.assign({}, state.scene, {
-        notifications: newNotifications
-      });
-      return {
-        ...state,
-        scene: newScene,
+        scene: action.scene,
       };
     default:
       return state;


### PR DESCRIPTION
<!--- Keep this line &  above for command line hub users -->
## Description

<!--- Describe your changes in detail -->

Refactor notifications queue (now called memos) into it's own part of the store with it's own reducer. Implemented multiple message queueing/dequeueing.
## Related Issue(s)

<!--- Please link to the issue here using 'closing' or 'connected': -->

Resolves #127 
Resolves #133 
## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes and any tests you've written. -->

Manually (dispatching GAME_MEMO action) and with npm test.
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [X] Major refactor (fix or feature that would cause existing functionality to change)
- [ ] Documentation change (Check this if you changed any documentation at all)
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] My code follows the code style of this project.
- [X] I have rebased and squashed my commits.
- [] I have added tests to cover my changes.
- [X] All new and existing tests passed.
- [ ] My change requires a change to the documentation.

…. Implement queueing/dequeuing of multilple memos.
