### PR TITLE
FEAT - Style clues to appear in a line and in a chat bubble

### DIFF
--- a/app/components/ClueMessage.js
+++ b/app/components/ClueMessage.js
@@ -3,12 +3,29 @@ import React, {
   StyleSheet,
   View,
   PropTypes,
+  Text,
 } from 'react-native';
 import Emoji from './Emoji.js';
 
 const styles = StyleSheet.create({
   container: {
-
+    flexDirection: 'column',
+  },
+  body: {
+    flex: 1,
+    flexDirection: 'row',
+  },
+  messageMeta: {
+    flex: 1,
+  },
+  messageMetaFont: {
+    flex: 1,
+    color: 'grey',
+  },
+  messageBubble: {
+    padding: 15,
+    borderRadius: 4,
+    backgroundColor: '#EEEEEE',
   },
 });
 
@@ -20,11 +37,20 @@ const styles = StyleSheet.create({
 
 const ClueMessage = ({ userId, time, body, currentUser, players, screenSize }) => (
   <View style={styles.container}>
-    {
-      body.map(
-        ([sheetX, sheetY], index) => (<Emoji key={index} x={sheetX} y={sheetY} />)
-      )
-    }
+    <View style={styles.messageMeta}>
+      <Text style={styles.messageMetaFont}>
+      {userId === currentUser.id ? 'me' : players.all[userId].username}
+      </Text>
+    </View>
+    <View style={styles.messageBubble}>
+      <View style={styles.body}>
+        {
+          body.map(
+            ([sheetX, sheetY], index) => (<Emoji key={index} x={sheetX} y={sheetY} />)
+          )
+        }
+      </View>
+    </View>
   </View>
 );
 


### PR DESCRIPTION
<!--- Keep this line &  above for command line hub users -->
## Description

<!--- Describe your changes in detail -->

The clue emoji messages were appearing in a column since they were not
previously styled.  They now appear in a chat bubble in a row.
## Related Issue(s)

<!--- Please link to the issue here using 'closing' or 'connected': -->

Closes #186
## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes and any tests you've written. -->

Manually
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Major refactor (fix or feature that would cause existing functionality to change)
- [ ] Documentation change (Check this if you changed any documentation at all)
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] My code follows the code style of this project.
- [x] I have rebased and squashed my commits.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My change requires a change to the documentation.
