### PR TITLE
BUG - Users now move to homescreen on socket disconnect

### DIFF
--- a/app/App.js
+++ b/app/App.js
@@ -13,8 +13,15 @@ import DealerChangeScreen from './screens/DealerChangeScreen.js';
 import config from './utils/config.js';
 
 /* Import Store */
-import configureStore from './store/configureStore.js';
+import { socket, configureStore } from './store/configureStore.js';
 const store = configureStore({});
+
+socket.on('disconnect', () => {
+  // TODO: Add logic for figuring out whether you've intentionally 
+  // disconnected and if not, we should display error in toast so the
+  // user knows why they've been dumped back in the home screen
+  Actions.showHomeScreen();
+});
 
 /* Setup store with fake game data REMOVE FOR PRODUCTION*/
 // import { fakeGameCreator, makeFakeMessageAdder } from './testdata/dummyData.js';

--- a/app/store/configureStore.js
+++ b/app/store/configureStore.js
@@ -2,6 +2,7 @@
 
 /* Import Dependencies */
 import { createStore, applyMiddleware, compose } from 'redux';
+import { Actions } from 'react-native-router-flux';
 import config from '../utils/config.js';
 
 /* Import Reducer */
@@ -17,14 +18,15 @@ import devTools from 'remote-redux-devtools';
  */
 import './UserAgent';
 import io from 'socket.io-client/socket.io';
-const socket = io.connect(config.serverUrl, {
+export const socket = io.connect(config.serverUrl, {
   jsonp: false,
   transports: ['websocket'],
 });
+
 import createSocketIoMiddleware from 'redux-socket.io';
 const socketIoMiddleware = createSocketIoMiddleware(socket, 'server/');
 
-export default function configureStore(initialState) {
+export function configureStore(initialState) {
   const enhancer = compose(
     applyMiddleware(thunk, socketIoMiddleware),
     devTools({
@@ -36,3 +38,4 @@ export default function configureStore(initialState) {
   );
   return createStore(rootReducer, initialState, enhancer);
 }
+


### PR DESCRIPTION
<!--- Keep this line &  above for command line hub users -->
## Description

<!--- Describe your changes in detail -->

Before, there was a bug where when a socket connection was disconnected, either
intentionally or not, the game silently stopped working.  It looks like you can
send messages but really, the game has kicked you out and there is no way to tell
on the front end.  Now at least you're booted to the homescreen...

TODO: Add a way to add conditional toast so that when you're socket connection fails
it tells you that there was a network error and that's why you're back at the homescreen,
but if you intentionally leaving a game it will not show this message.
## Related Issue(s)

<!--- Please link to the issue here using 'closing' or 'connected': -->

Closes #190
## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes and any tests you've written. -->

Manually
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Major refactor (fix or feature that would cause existing functionality to change)
- [ ] Documentation change (Check this if you changed any documentation at all)
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] My code follows the code style of this project.
- [x] I have rebased and squashed my commits.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] My change requires a change to the documentation.
