### PR TITLE
FEAT - Make stats screen work with new variable names

### DIFF
--- a/app/screens/StatsScreen.js
+++ b/app/screens/StatsScreen.js
@@ -109,8 +109,8 @@ class StatsScreen extends Component {
           style={styles.thumbnail}
         />
         <Text style={styles.username}>{player.username}</Text>
-        <Text style={styles.points}>{player.points}</Text>
-        <Text style={styles.wins}>{player.wins}</Text>
+        <Text style={styles.points}>{player.roundsWon}</Text>
+        <Text style={styles.wins}>{player.gamesWon}</Text>
         <Text style={styles.emojicoins}>{player.emojicoins}</Text>
       </View>
     );


### PR DESCRIPTION
<!--- Keep this line &  above for command line hub users -->
## Description

<!--- Describe your changes in detail -->

Since the variable names changed on the server from:
points->roundsWon
wins->gamesWon
I had to change the client code to accomodate
## Related Issue(s)

<!--- Please link to the issue here using 'closing' or 'connected': -->

Closes #210
## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes and any tests you've written. -->

Manually
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Major refactor (fix or feature that would cause existing functionality to change)
- [ ] Documentation change (Check this if you changed any documentation at all)
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] My code follows the code style of this project.
- [x] I have rebased and squashed my commits.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My change requires a change to the documentation.
